### PR TITLE
Factory-like functionality

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -129,7 +129,7 @@ pytest-qt==4.4.0
     # via -r requirements-dev.in
 pywin32-ctypes==0.2.2
     # via pyinstaller
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   bandit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -154,7 +154,7 @@ types-markdown==3.6.0.20240316
     # via -r requirements-dev.in
 types-pyyaml==6.0.12.20240724
     # via -r requirements-dev.in
-types-setuptools==71.1.0.20240726
+types-setuptools==71.1.0.20240806
     # via -r requirements-dev.in
 typing-extensions==4.12.2
     # via

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -85,7 +85,7 @@ pymdown-extensions==10.9
     # via mkdocs-material
 python-dateutil==2.9.0.post0
     # via ghp-import
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements-dev.txt
     #   mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pyside6-essentials==6.7.2
     # via
     #   pyside6
     #   pyside6-addons
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via -r requirements.in
 shiboken6==6.7.2
     # via

--- a/src/show_dialog/inputs.py
+++ b/src/show_dialog/inputs.py
@@ -102,3 +102,20 @@ class Inputs(JSONFileMixin):
 
     Can be a resource path, relative path or absolute path. See examples under ``assets/inputs``.
     """
+
+
+class InputsFactory:
+    """
+    Create instances of ``Inputs`` with the defaults set in ``inputs``.
+    """
+
+    def __init__(self, defaults: Inputs):
+        self.defaults = defaults
+
+    def create(self, inputs: Inputs) -> Inputs:
+        """
+        Generate a new instance of ``Inputs`` with the defaults set in the constructor.
+        """
+        inputs_default = self.defaults.to_dict()
+        new_inputs = {k: v for k, v in inputs.to_dict().items() if v}
+        return inputs.from_dict(inputs_default | new_inputs)

--- a/src/show_dialog/inputs.py
+++ b/src/show_dialog/inputs.py
@@ -73,9 +73,19 @@ class JSONFileMixin(DataClassJSONMixin):
 
 
 class DefaultsMixin(DataClassDictMixin):
+    """
+    Add factory-like functionality.
+    """
+
     def create(self, new_instance: DataClassDictMixin):
+        """
+        Create a new instance with this instance's values as defaults.
+
+        Note that boolean fields are never updated.
+        """
         defaults = self.to_dict()
         new_values = {k: v for k, v in new_instance.to_dict().items() if v or isinstance(v, bool)}
+
         return self.__class__.from_dict(defaults | new_values)
 
 

--- a/tests/tests/test_inputs.py
+++ b/tests/tests/test_inputs.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from pytest_params import params
 
-from src.show_dialog.inputs import DataFileType, Inputs
+from src.show_dialog.inputs import DataFileType, Inputs, InputsFactory
 from tests.libs.fixtures import inputs_instance  # noqa: F401
 
 
@@ -84,3 +84,9 @@ class TestInputs:
         file = tmp_path / 'foo.bar'
         with pytest.raises(ValueError):
             Inputs.from_file(file)
+
+
+class TestInputsFactory:
+    def test_create(self):
+        base = InputsFactory()
+        factory = InputsFactory()

--- a/tests/tests/test_inputs.py
+++ b/tests/tests/test_inputs.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from pytest_params import params
 
-from src.show_dialog.inputs import DataFileType, Inputs, InputsFactory
+from src.show_dialog.inputs import DataFileType, Inputs
 from tests.libs.fixtures import inputs_instance  # noqa: F401
 
 
@@ -91,3 +91,15 @@ class TestInputs:
 
         assert isinstance(new, Inputs)
         assert new == Inputs(title='Foo', description='Baz', dialog_title='qux')
+
+    def test_create_with_boolean(self):
+        """
+        Boolean fields are not taken into consideration when creating new instances with the current
+        instance as defaults.
+        """
+        base = Inputs(description_md=True)
+        new_inputs = Inputs()
+        assert new_inputs.description_md is False
+        new = base.create(new_inputs)
+
+        assert new.description_md is False

--- a/tests/tests/test_inputs.py
+++ b/tests/tests/test_inputs.py
@@ -85,8 +85,9 @@ class TestInputs:
         with pytest.raises(ValueError):
             Inputs.from_file(file)
 
-
-class TestInputsFactory:
     def test_create(self):
-        base = InputsFactory()
-        factory = InputsFactory()
+        base = Inputs(title='Foo', description='Bar')
+        new = base.create(Inputs(description='Baz', dialog_title='qux'))
+
+        assert isinstance(new, Inputs)
+        assert new == Inputs(title='Foo', description='Baz', dialog_title='qux')


### PR DESCRIPTION
Ability to create a new instance of `Inputs` from an existing instance that will contain default values.
The new instance will have the new values specified in the constructor and the existing values for the fields not specified in the constructor.

Resolves #20 