### PR TITLE
Remove manifest and fix app build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ which includes _Qt Designer_, a WYSIWYG UI editor.
 ## Getting started
 ### Requirements
 ```
-pip install -r requirements-dev.txt
+pip install qt-show-dialog
 ```
 
 Documentation: [https://joaonc.github.io/show_dialog](https://joaonc.github.io/show_dialog/)

--- a/assets/app.yaml
+++ b/assets/app.yaml
@@ -1,7 +1,0 @@
-# App manifest
-
-build_time:
-file_name:
-file_sha1:
-git_commit:
-version: '0.1.0'

--- a/assets/inputs/inputs_11.yaml
+++ b/assets/inputs/inputs_11.yaml
@@ -3,7 +3,8 @@ dialog_title: inputs_11
 title: Timeout
 description: |
     This dialog has a timeout,
-    after which it is dismissed.
+    after which it is dismissed
+    and returns 1 (error).
 timeout: 10
-timeout_pass: true
+timeout_pass: false
 timeout_text: '%v'

--- a/assets/pyinstaller.spec
+++ b/assets/pyinstaller.spec
@@ -7,13 +7,16 @@
 from pathlib import Path
 
 PROJECT_ROOT = Path(SPECPATH).parent.resolve(strict=True)
-PROJECT_NAME = PROJECT_ROOT.name
-ASSETS_DIR = PROJECT_ROOT / 'assets'
-SOURCE_DIR = PROJECT_ROOT / 'src' / PROJECT_NAME
+#PROJECT_NAME = PROJECT_ROOT.name
+#ASSETS_DIR = PROJECT_ROOT / 'assets'
+#SOURCE_DIR = PROJECT_ROOT / 'src' / PROJECT_NAME
+
+BUILD_WORK_DIR = PROJECT_ROOT / 'build'
+BUILD_WORK_APP_DIR = BUILD_WORK_DIR / 'app'
 
 
 a = Analysis(
-    [str('src/show_dialog/main.py')],
+    [str(BUILD_WORK_APP_DIR / 'src/show_dialog/main.py')],
     pathex=[],
     binaries=[],
     # https://pyinstaller.org/en/stable/spec-files.html#adding-data-files

--- a/assets/pyinstaller.spec
+++ b/assets/pyinstaller.spec
@@ -7,10 +7,6 @@
 from pathlib import Path
 
 PROJECT_ROOT = Path(SPECPATH).parent.resolve(strict=True)
-#PROJECT_NAME = PROJECT_ROOT.name
-#ASSETS_DIR = PROJECT_ROOT / 'assets'
-#SOURCE_DIR = PROJECT_ROOT / 'src' / PROJECT_NAME
-
 BUILD_WORK_DIR = PROJECT_ROOT / 'build'
 BUILD_WORK_APP_DIR = BUILD_WORK_DIR / 'app'
 

--- a/assets/pyinstaller.spec
+++ b/assets/pyinstaller.spec
@@ -10,20 +10,14 @@ PROJECT_ROOT = Path(SPECPATH).parent.resolve(strict=True)
 PROJECT_NAME = PROJECT_ROOT.name
 ASSETS_DIR = PROJECT_ROOT / 'assets'
 SOURCE_DIR = PROJECT_ROOT / 'src' / PROJECT_NAME
-APP_MANIFEST_FILE = ASSETS_DIR / 'app.yaml'
 
 
 a = Analysis(
-    [str(SOURCE_DIR / 'main.py')],
+    [str('src/show_dialog/main.py')],
     pathex=[],
     binaries=[],
     # https://pyinstaller.org/en/stable/spec-files.html#adding-data-files
-    datas=[
-        (
-            str(APP_MANIFEST_FILE),
-            str(ASSETS_DIR.relative_to(PROJECT_ROOT)),
-        ),
-    ],
+    datas=[],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,10 +94,8 @@ You can authenticate in other ways, see
 [docs](https://cli.github.com/manual/gh_auth_login) for more info.
 
 #### Create release
-1. Update (increase) the app version in `assets/app.yaml`.
-2. Create and merge a new PR called _"Preparing for v1.2.3"_ release.  
-   This merges the new version, which will be used to create the release and set it to the right
-   commit hash.
+1. Update (increase) version with `inv build.version`.
+2. Create and merge a new PR called _"Release 1.2.3"_.  
 3. Run `inv build.release`
    Use the `--notes` or `--notes-file` to add more details to the release.  
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,5 +6,5 @@ The initial use case is to show instructions in manual steps in tests.
 ## Getting started
 ### Requirements
 ```
-pip install -r requirements-dev.txt
+pip install qt-show-dialog
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Configuration for tools that don't support `pyproject.toml`.
 
 [flake8]
-extend-exclude = src/show_dialog/ui/forms,tests/libs/resources_rc.py,.venv*,venv*,.git,.github,assets,dist,docs,site,__pycache__
+extend-exclude = src/show_dialog/ui/forms,tests/libs/resources_rc.py,.venv*,venv*,.git,.github,assets,build,dist,docs,site,__pycache__
 max-line-length = 100
 # Errors being ignored:
 # E203 is not PEP8 compliant and clashes with black

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,18 @@
 from pathlib import Path
 
-import yaml
 from setuptools import setup
+
+import src.show_dialog
 
 PROJECT_ROOT = Path(__file__).parent
 ASSETS_DIR = PROJECT_ROOT / 'assets'
-
-with open(ASSETS_DIR / 'app.yaml') as f:
-    manifest = yaml.safe_load(f)
 
 with open(PROJECT_ROOT / 'README.md') as f:
     long_description = f.read()
 
 setup(
     name='show-dialog',
-    version=manifest['version'],
+    version=src.show_dialog.__version__,
     py_modules=['show_dialog'],
     provides=['show_dialog'],
     description='Easily show a dialog',

--- a/src/show_dialog/__init__.py
+++ b/src/show_dialog/__init__.py
@@ -1,5 +1,5 @@
-from .main import main
+# from .main import main
 
 __version__ = '0.1.0'
 
-__all__ = ['main']
+# __all__ = ['main']

--- a/src/show_dialog/__init__.py
+++ b/src/show_dialog/__init__.py
@@ -1,1 +1,5 @@
+from .main import main
+
 __version__ = '0.1.0'
+
+__all__ = ['main']

--- a/src/show_dialog/config.py
+++ b/src/show_dialog/config.py
@@ -8,13 +8,6 @@ import os
 import sys
 from pathlib import Path
 
-import yaml
-
-
-def read_manifest_file(manifest) -> dict:
-    with open(manifest) as f:
-        return yaml.safe_load(f)  # type: ignore
-
 
 def is_truthy(value) -> bool:
     return str(value).strip().lower() in ['true', '1']

--- a/src/show_dialog/config.py
+++ b/src/show_dialog/config.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 
 import yaml
-from packaging.version import Version
 
 
 def read_manifest_file(manifest) -> dict:
@@ -46,21 +45,10 @@ else:
     PROJECT_ROOT = Path(__file__).parents[2]
 
 ASSETS_DIR = PROJECT_ROOT / 'assets'
-APP_MANIFEST_FILE = ASSETS_DIR / 'app.yaml'
 # endregion
 
 # region Global constants
 ORGANIZATION_NAME = 'Show Dialog'
 ORGANIZATION_DOMAIN = 'qt-show-dialog.app'  # Does not exist. To avoid build issues on Mac.
 APPLICATION_NAME = 'Show Dialog'
-# endregion
-
-# region General configs
-app_manifest = read_manifest_file(APP_MANIFEST_FILE)
-"""
-App manifest contents (as a dict).
-"""
-
-version = Version(app_manifest['version'])
-"""App version."""
 # endregion

--- a/src/show_dialog/main.py
+++ b/src/show_dialog/main.py
@@ -27,7 +27,9 @@ def _set_config_values() -> tuple[Inputs, str | None]:
     """
     from argparse import ArgumentParser, RawTextHelpFormatter
 
-    description = f'Show Dialog {config.version}'
+    from . import __version__
+
+    description = f'Show Dialog {__version__}'
 
     parser = ArgumentParser(description=description, formatter_class=RawTextHelpFormatter)
     parser.add_argument(
@@ -60,14 +62,14 @@ def _set_config_values() -> tuple[Inputs, str | None]:
         '-v',
         '--version',
         action='version',
-        version=str(config.version),
+        version=__version__,
     )
 
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.getLevelName(args.log_level.upper()))
     logging.debug(
-        f'Show Dialog.\n  App version: {config.version}\n  Log level: {args.log_level}\n  '
+        f'Show Dialog.\n  App version: {__version__}\n  Log level: {args.log_level}\n  '
         f'File: {sys.executable}'
     )
 

--- a/src/show_dialog/main.py
+++ b/src/show_dialog/main.py
@@ -5,7 +5,7 @@ import types
 
 from PySide6.QtWidgets import QApplication
 
-from . import config
+from . import __version__, config
 from .inputs import Inputs
 from .ui.show_dialog import ShowDialog
 from .utils_qt import list_resources, read_resource_file
@@ -26,8 +26,6 @@ def _set_config_values() -> tuple[Inputs, str | None]:
     Parse CLI arguments and set ``config`` values.
     """
     from argparse import ArgumentParser, RawTextHelpFormatter
-
-    from . import __version__
 
     description = f'Show Dialog {__version__}'
 

--- a/src/show_dialog/ui/show_dialog.py
+++ b/src/show_dialog/ui/show_dialog.py
@@ -100,6 +100,7 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         new_value = self.timeout_progress_bar.value() - self.timer.interval() / 1000
         self.timeout_progress_bar.setValue(new_value)
         if new_value <= 0:
+            logging.debug('Timeout.')
             if self.inputs.timeout_pass:
                 self.pass_clicked()
             else:

--- a/tasks.py
+++ b/tasks.py
@@ -352,10 +352,10 @@ def build_app(c, no_spec: bool = False, no_zip: bool = False):
     # Build executable
     if no_spec:
         build_source_dir = BUILD_WORK_APP_DIR / PROJECT_SOURCE_DIR.relative_to(PROJECT_ROOT)
-        build_in_file = build_source_dir / PROJECT_NAME / 'main.py'
+        build_input_file = build_source_dir / PROJECT_NAME / 'main.py'
         c.run(
             f'pyinstaller '
-            f'--onefile "{build_in_file}" --distpath "{BUILD_DIST_APP_DIR}" '
+            f'--onefile "{build_input_file}" --distpath "{BUILD_DIST_APP_DIR}" '
             f'--workpath "{BUILD_WORK_APP_DIR}" --specpath "{BUILD_WORK_APP_DIR}"'
         )
     else:


### PR DESCRIPTION
* Removed the `assets/app.yaml` manifest file.  
  Not needed in this project.
* Fixed the executable build.  
  Had an import issue and was fixed by copying the code to a separate location (in the `build` directory) and changing the imports to absolute.