### PR TITLE
Dependencies fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ readme = 'README.md'
 authors = [{name = 'Joao Coelho'}]
 license = {file = 'LICENSE.txt'}
 requires-python = '>=3.10'
-dependencies = ['markdown', 'mashumaro', 'pyside6', 'pyyaml']
+dependencies = ['markdown', 'mashumaro', 'pyside6', 'pyyaml', 'qdarkstyle']
 keywords = ['python', 'qt', 'qt6', 'testing', 'manual']
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,5 @@
+# When updating this file, update pyptoject.toml::project::dependencies
+
 markdown            # Convert markdown to html
 mashumaro           # JSON/YAML class serialization
 pyside6             # Qt


### PR DESCRIPTION
Added `qdarkstyle` in `pyproject.toml > project > dependencies`, which is required for proper dependencies installation when installing `qt-show-dialog` as a package.