### PR TITLE
Ok button option

### DIFF
--- a/assets/inputs/inputs_10.yaml
+++ b/assets/inputs/inputs_10.yaml
@@ -25,4 +25,4 @@ description: |
         <p>This is <span class="highlight">highlighted</span> text.</p>
     </body>
     </html>
-buttons: Ok
+buttons: Ok/Cancel

--- a/assets/inputs/inputs_10.yaml
+++ b/assets/inputs/inputs_10.yaml
@@ -21,7 +21,8 @@ description: |
         </style>
     </head>
     <body>
-        <p>This is <span class="strike">trike through and red</span> text.</p>
+        <p>This is <span class="strike">strike through and red</span> text.</p>
         <p>This is <span class="highlight">highlighted</span> text.</p>
     </body>
     </html>
+buttons: Ok

--- a/assets/inputs/inputs_11.yaml
+++ b/assets/inputs/inputs_11.yaml
@@ -5,6 +5,6 @@ description: |
     This dialog has a timeout,
     after which it is dismissed
     and returns an error code.
-timeout: 10
+timeout: 20
 timeout_pass: false
 timeout_text: '%v'

--- a/src/show_dialog/__init__.py
+++ b/src/show_dialog/__init__.py
@@ -1,5 +1,5 @@
 from .exit_code import ExitCode
-from .inputs import DataFileType, Inputs
+from .inputs import Buttons, DataFileType, Inputs
 from .main import main, show_dialog
 from .style import Style
 from .ui.show_dialog import ShowDialog
@@ -7,6 +7,7 @@ from .ui.show_dialog import ShowDialog
 __version__ = '0.6.0'
 
 __all__ = [
+    'Buttons',
     'DataFileType',
     'ExitCode',
     'Inputs',

--- a/src/show_dialog/inputs.py
+++ b/src/show_dialog/inputs.py
@@ -37,11 +37,18 @@ class Buttons(str, Enum):
     """
     Show only an OK button.
 
-    If the input option ``pass_button_text`` is not specified, the text will be ``'Ok'``.
+    * If ``pass_button_text`` is not specified, the text will be ``'Ok'``.
+    * If ``pass_button_icon`` is not specified, no icon will be shown.
     """
     PASS_FAIL = 'Pass/Fail'
     """
     Pass/Fail buttons.
+
+    Text can be modified with the input options ``pass_button_text`` and ``fail_button_text``.
+    """
+    OK_CANCEL = 'Ok/Cancel'
+    """
+    Ok/Cancel buttons.
 
     Text can be modified with the input options ``pass_button_text`` and ``fail_button_text``.
     """

--- a/src/show_dialog/inputs.py
+++ b/src/show_dialog/inputs.py
@@ -30,6 +30,23 @@ class DataFileType(Enum):
         return file_type
 
 
+class Buttons(str, Enum):
+    """Buttons displayed in the dialog."""
+
+    OK = 'Ok'
+    """
+    Show only an OK button.
+
+    If the input option ``pass_button_text`` is not specified, the text will be ``'Ok'``.
+    """
+    PASS_FAIL = 'Pass/Fail'
+    """
+    Pass/Fail buttons.
+
+    Text can be modified with the input options ``pass_button_text`` and ``fail_button_text``.
+    """
+
+
 class JSONFileMixin(DataClassJSONMixin):
     """
     Adds the ability to load from file and save to file.
@@ -134,6 +151,12 @@ class Inputs(JSONFileMixin, DefaultsMixin):
 
     * ``'%p%'`` to show percentage completed, ex '15%'
     * ``'%vs'`` to show the number of seconds elapsed, ex '15s'
+    """
+    buttons: Buttons = Buttons.PASS_FAIL
+    """
+    Set the buttons displayed.
+
+    See the ``Buttons`` class for available options.
     """
     pass_button_text: str = ''
     pass_button_icon: str = ''

--- a/src/show_dialog/ui/show_dialog.py
+++ b/src/show_dialog/ui/show_dialog.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import QApplication, QDialog
 from qdarkstyle.light.palette import LightPalette
 
 from ..exit_code import ExitCode
-from ..inputs import Inputs
+from ..inputs import Buttons, Inputs
 from ..utils_qt import set_layout_visibility
 from .forms.ui_show_dialog import Ui_ShowDialog
 
@@ -28,6 +28,9 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         self.timer = None
 
         # UI adjustments
+        local_stylesheet = ''
+        """Stylesheet modifications that depend on inputs."""
+
         self.title_label.setText(self.inputs.title)
         if self.inputs.description_md:
             description = markdown.markdown(self.inputs.description)
@@ -37,6 +40,15 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         self.description_label.setText(description)
         if self.inputs.dialog_title:
             self.setWindowTitle(self.inputs.dialog_title)
+
+        # Buttons
+        if inputs.buttons == Buttons.OK:
+            # These settings may be overridden further below from `inputs`
+            self.fail_button.setVisible(False)
+            self.pass_button.setText('Ok')
+            self.pass_button.setIcon(QIcon.fromTheme(QIcon.ThemeIcon.InputGaming))
+            local_stylesheet += 'QPushButton#pass_button { color : black; }'
+
         if self.inputs.pass_button_text:
             self.pass_button.setText(self.inputs.pass_button_text)
         if self.inputs.pass_button_icon:
@@ -55,6 +67,8 @@ class ShowDialog(QDialog, Ui_ShowDialog):
                     f'Icon image for FAIL button not found: {self.inputs.fail_button_icon}'
                 )
             self.fail_button.setIcon(icon)
+
+        # Timeout
         if self.inputs.timeout:
             self.timeout_increase_button.setIconSize(self.timeout_increase_button.size())
             self.timeout_increase_button.clicked.connect(self.timeout_increase_clicked)
@@ -72,10 +86,11 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         else:
             set_layout_visibility(self.timeout_h_layout, False)
 
+        # Stylesheet
         stylesheet_app = qdarkstyle.load_stylesheet(palette=LightPalette)
         if self.stylesheet:
             # Combine the two stylesheets
-            stylesheet_app += self.stylesheet
+            stylesheet_app += self.stylesheet + local_stylesheet
         self.app.setStyleSheet(stylesheet_app)
 
         # UI bindings

--- a/src/show_dialog/ui/show_dialog.py
+++ b/src/show_dialog/ui/show_dialog.py
@@ -45,9 +45,13 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         if inputs.buttons == Buttons.OK:
             # These settings may be overridden further below from `inputs`
             self.fail_button.setVisible(False)
-            self.pass_button.setText('Ok')
-            self.pass_button.setIcon(QIcon.fromTheme(QIcon.ThemeIcon.InputGaming))
+            self.pass_button.setText(Buttons.OK)
+            self.pass_button.setIcon(QIcon())
             local_stylesheet += 'QPushButton#pass_button { color : black; }'
+        elif inputs.buttons == Buttons.OK_CANCEL:
+            pass_text, fail_text = Buttons.OK_CANCEL.split('/')
+            self.pass_button.setText(pass_text)
+            self.fail_button.setText(fail_text)
 
         if self.inputs.pass_button_text:
             self.pass_button.setText(self.inputs.pass_button_text)

--- a/tests/tests/ui/test_show_dialog.py
+++ b/tests/tests/ui/test_show_dialog.py
@@ -6,7 +6,7 @@ from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 from pytest_params import params
 
-from src.show_dialog import ExitCode, Inputs, ShowDialog
+from src.show_dialog import Buttons, ExitCode, Inputs, ShowDialog
 from tests.libs import config
 
 
@@ -126,6 +126,19 @@ def test_pass_shortcut(exit_mock, show_dialog: ShowDialog):
 def test_pass_fail_buttons_text(show_dialog: ShowDialog, expected_pass_fail_text: tuple[str, str]):
     assert show_dialog.pass_button.text() == expected_pass_fail_text[0]
     assert show_dialog.fail_button.text() == expected_pass_fail_text[1]
+
+
+@params(
+    'show_dialog, expected_button_text',
+    [
+        ('default text', Inputs(buttons=Buttons.OK), 'Ok'),
+        ('custom text', Inputs(buttons=Buttons.OK, pass_button_text='Foo'), 'Foo'),
+    ],
+    indirect=['show_dialog'],
+)
+def test_ok_button(show_dialog: ShowDialog, expected_button_text: str):
+    assert not show_dialog.fail_button.isVisible()
+    assert show_dialog.pass_button.text() == expected_button_text
 
 
 @params(

--- a/tests/tests/ui/test_show_dialog.py
+++ b/tests/tests/ui/test_show_dialog.py
@@ -142,6 +142,26 @@ def test_ok_button(show_dialog: ShowDialog, expected_button_text: str):
 
 
 @params(
+    'show_dialog, expected_pass_button_text, expected_fail_button_text',
+    [
+        ('default text', Inputs(buttons=Buttons.OK_CANCEL), 'Ok', 'Cancel'),
+        (
+            'custom text',
+            Inputs(buttons=Buttons.OK_CANCEL, pass_button_text='Foo', fail_button_text='Bar'),
+            'Foo',
+            'Bar',
+        ),
+    ],
+    indirect=['show_dialog'],
+)
+def test_ok_cancel_button(
+    show_dialog: ShowDialog, expected_pass_button_text: str, expected_fail_button_text: str
+):
+    assert show_dialog.pass_button.text() == expected_pass_button_text
+    assert show_dialog.fail_button.text() == expected_fail_button_text
+
+
+@params(
     'show_dialog',
     [
         ('no timeout - default', Inputs()),


### PR DESCRIPTION
Ability to have only one button with the default text `'Ok'`.
Also made easier to have `Ok/Cancel` instead of the default `Pass/Fail`.  This functionality was possible before, but needed to set `pass_button_text` and `fail_button_text` inputs, which is a bit harder.

Resolves https://github.com/joaonc/show_dialog/issues/60