### PR TITLE
Fix: Re-use app instance

### DIFF
--- a/src/show_dialog/main.py
+++ b/src/show_dialog/main.py
@@ -30,7 +30,7 @@ def show_dialog(
         * ``return``: Return an ``ExitCode``, regardless of whether there was an error.
     """
 
-    app = QApplication.instance()
+    app: QApplication = QApplication.instance()  # type: ignore
     if not app:
         app = QApplication()
     window = ShowDialog(app, inputs, stylesheet)

--- a/src/show_dialog/main.py
+++ b/src/show_dialog/main.py
@@ -30,10 +30,13 @@ def show_dialog(
         * ``return``: Return an ``ExitCode``, regardless of whether there was an error.
     """
 
-    app = QApplication()
+    app = QApplication.instance()
+    if not app:
+        app = QApplication()
     window = ShowDialog(app, inputs, stylesheet)
     window.show()
     app_response = app.exec()
+    app.closeAllWindows()
     exit_code = ExitCode(app_response)
 
     if exit_code is not ExitCode.Pass:


### PR DESCRIPTION
`QApplication` is a singleton in Qt.  In a test case where we want to show more than one dialog, that instance needs to be re-used.  This PR fixes that.