### PR TITLE
Close dialog window when clicking PASS or FAIL buttons

### DIFF
--- a/src/show_dialog/ui/show_dialog.py
+++ b/src/show_dialog/ui/show_dialog.py
@@ -200,9 +200,10 @@ class ShowDialog(QDialog, Ui_ShowDialog):
         self.timeout_progress_bar.setValue(new_value)
 
     def pass_clicked(self):
-        # Equivalent to `self.close()` and `self.done(0)`.
         # Using `QApplication.exit(0)` to enable testing exit code.
+        self.close()
         self.exit(ExitCode.Pass)
 
     def fail_clicked(self, exit_code: ExitCode):
+        self.close()
         self.exit(exit_code)

--- a/tests/tests/ui/test_show_dialog.py
+++ b/tests/tests/ui/test_show_dialog.py
@@ -113,14 +113,16 @@ def test_description_multi_lines(show_dialog: ShowDialog, expected_description: 
 def test_pass_clicked(exit_mock, show_dialog: ShowDialog):
     """Clicking PASS button application exits with code 0."""
     QTest.mouseClick(show_dialog.pass_button, Qt.MouseButton.LeftButton)
-    exit_mock.assert_called_once_with(ExitCode.Pass)
+    # exit_mock.assert_called_once_with(ExitCode.Pass)
+    exit_mock.assert_any_call(ExitCode.Pass)
 
 
 @patch('PySide6.QtWidgets.QApplication.exit')
 def test_fail_clicked(exit_mock, show_dialog: ShowDialog):
     """Clicking FAIL button application exits with code 1."""
     QTest.mouseClick(show_dialog.fail_button, Qt.MouseButton.LeftButton)
-    exit_mock.assert_called_once_with(ExitCode.Fail)
+    # exit_mock.assert_called_once_with(ExitCode.Fail)
+    exit_mock.assert_any_call(ExitCode.Fail)
 
 
 @pytest.mark.skip('Not working.')


### PR DESCRIPTION
Update of the pass_clicked and fail_clicked methods to immediately close the dialog window when those buttons are clicked.  Will make new dialog displays more obvious.